### PR TITLE
Fix build command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ check your printer for firmware updates, which might fix the bug.
       ```shell
    pyinstaller --onefile --add-binary="libs/ColPic_X64.dll:libs" --add-binary="libs/libColPic.so:libs" --add-binary="libs/libColPic.dylib:libs" --name="ElegooNeptuneThumbnails-Prusa" elegoo_neptune_thumbnails.py
    ```
-4) Binary is in `dist` folder
+3) Binary is in `dist` folder
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ check your printer for firmware updates, which might fix the bug.
 1) Install requirements `pip install -r requirements.txt`
 2) Create binary for your system
    ```shell
-   pyinstaller --onefile --add-binary="libs/ColPic_X64.dll;libs" --add-binary="libs/libColPic.so;libs" --add-binary="libs/libColPic.dylib;libs" --name="ElegooNeptuneThumbnails-Prusa" elegoo_neptune_thumbnails.py
+   pyinstaller --onefile --add-binary="libs/ColPic_X64.dll:libs" --add-binary="libs/libColPic.so:libs" --add-binary="libs/libColPic.dylib:libs" --name="ElegooNeptuneThumbnails-Prusa" elegoo_neptune_thumbnails.py
    ```
 3) Binary is in `dist` folder
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,16 @@ check your printer for firmware updates, which might fix the bug.
 
 1) Install requirements `pip install -r requirements.txt`
 2) Create binary for your system
+   
+   Windows:
    ```shell
+   pyinstaller --onefile --add-binary="libs/ColPic_X64.dll;libs" --add-binary="libs/libColPic.so;libs" --add-binary="libs/libColPic.dylib;libs" --name="ElegooNeptuneThumbnails-Prusa" elegoo_neptune_thumbnails.py
+   ```
+   Mac/Linux:
+      ```shell
    pyinstaller --onefile --add-binary="libs/ColPic_X64.dll:libs" --add-binary="libs/libColPic.so:libs" --add-binary="libs/libColPic.dylib:libs" --name="ElegooNeptuneThumbnails-Prusa" elegoo_neptune_thumbnails.py
    ```
-3) Binary is in `dist` folder
+4) Binary is in `dist` folder
 
 ## License
 


### PR DESCRIPTION
@Molodos I think there's an error in the build command in the Readme here, at least with the current one I got the error. `pyinstaller: error: argument --add-binary: Wrong syntax, should be --add-binary=SOURCE:DEST`, changing it to use a colon like this instead of a semicolon as the error message suggests works as expected.