### PR TITLE
Replace Qt with PIL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyQt6
 pyinstaller
+pillow


### PR DESCRIPTION
Using Qt just for parsing PNG and resizing images is overkill. PIL is a much lighter alternative, so use PIL instead