### PR TITLE
Additional support for custom meta data

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,18 @@ Yes!
 
 ### How to change the displayed metadata?
 
-It is currently not possible. If you really need to, please consider using
-the [Cura plugin version](https://github.com/Molodos/ElegooNeptuneThumbnails) of this script.
+There exists a parameter for each corner which has a default value, but can be changed:
+* `--corner-top-left`: defaults to time estimate
+* `--corner-top-right`: defaults to model height
+* `--corner-bottom-left`: defaults to filament usage estimate in grams
+* `--corner-bottom-right`: defaults to filament cost estimate
+
+Each corner can be set to one of the following values:
+* `nothing`: does not display anything in the corner
+* `time_estimate`: displays the time estimate
+* `filament_grams_estimate`: displays the filament usage estimate in grams
+* `model_height`: displays the model height in millimeters
+* `filament_cost_estimate`: displays the filament cost estimate
 
 ### Why does the model height show "N/A" when using PrusaSlicer?
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,11 @@ Each corner can be set to one of the following values:
 * `nothing`: does not display anything in the corner
 * `time_estimate`: displays the time estimate
 * `filament_grams_estimate`: displays the filament usage estimate in grams
+* `layer_height`: displays the layer height in millimeters
 * `model_height`: displays the model height in millimeters
 * `filament_cost_estimate`: displays the filament cost estimate
+* `filament_meters_estimate`: displays the filament usage estimate in meters
+* `line_width`: displays the line width in millimeters
 
 ### Why does the model height show "N/A" when using PrusaSlicer?
 

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+from .thumbnail_generator import SliceData, ThumbnailGenerator

--- a/tools/thumbnail_generator.py
+++ b/tools/thumbnail_generator.py
@@ -7,14 +7,18 @@ class SliceData:
     Result data from slicing
     """
 
-    def __init__(self, time_seconds: int, printer_model: str, model_height: float, filament_grams: float,
-                 filament_cost: float, currency: str = None):
-        self.printer_model: str = printer_model
+    def __init__(self, printer_model: str, layer_height: float = 0.2, time_seconds: int = 3960, filament_meters: float = 3.9,
+                 filament_grams: float = 11.6, model_height: float = 48.0, filament_cost: float = 0.25,
+                 line_width: float = 0.4, currency: str = "€"):
+        self.printer_model = printer_model
+        self.layer_height: float = layer_height
         self.time_seconds: int = time_seconds
-        self.model_height: float = model_height
+        self.filament_meters: float = filament_meters
         self.filament_grams: float = filament_grams
+        self.model_height: float = model_height
         self.filament_cost: float = filament_cost
-        self.currency: str = currency if currency else "€"
+        self.line_width: float = line_width
+        self.currency: str = currency
 
 
 class ThumbnailGenerator:
@@ -34,6 +38,13 @@ class ThumbnailGenerator:
         return f"⭗ {round(slice_data.filament_grams)}g"
 
     @staticmethod
+    def _layer_height(slice_data: SliceData) -> str:
+        if slice_data.layer_height < 0:
+            return f"⧗ N/A"
+        else:
+            return f"⧗ {round(slice_data.layer_height, 2)}mm"
+
+    @staticmethod
     def _model_height(slice_data: SliceData) -> str:
         if slice_data.model_height < 0:
             return f"⭱ N/A"
@@ -43,6 +54,14 @@ class ThumbnailGenerator:
     @staticmethod
     def _filament_cost_estimate(slice_data: SliceData) -> str:
         return f"⛁ {round(slice_data.filament_cost, 2):.02f}{slice_data.currency}"
+
+    @staticmethod
+    def _filament_meters_estimate(slice_data: SliceData) -> str:
+        return f"⬌ {round(slice_data.filament_meters, 2):.02f}m"
+
+    @staticmethod
+    def _line_width(slice_data: SliceData) -> str:
+        return f"◯ {round(slice_data.line_width, 2):.02f}mm"
 
     @classmethod
     def available_options(cls) -> List[str]:
@@ -71,6 +90,9 @@ ThumbnailGenerator._corner_choices = {
     "nothing": ThumbnailGenerator._nothing,
     "time_estimate": ThumbnailGenerator._time_estimate,
     "filament_grams_estimate": ThumbnailGenerator._filament_grams_estimate,
+    "layer_height": ThumbnailGenerator._layer_height,
     "model_height": ThumbnailGenerator._model_height,
     "filament_cost_estimate": ThumbnailGenerator._filament_cost_estimate,
+    "filament_meters_estimate": ThumbnailGenerator._filament_meters_estimate,
+    "line_width": ThumbnailGenerator._line_width,
 }

--- a/tools/thumbnail_generator.py
+++ b/tools/thumbnail_generator.py
@@ -1,0 +1,76 @@
+from typing import Callable, List
+import math
+
+
+class SliceData:
+    """
+    Result data from slicing
+    """
+
+    def __init__(self, time_seconds: int, printer_model: str, model_height: float, filament_grams: float,
+                 filament_cost: float, currency: str = None):
+        self.printer_model: str = printer_model
+        self.time_seconds: int = time_seconds
+        self.model_height: float = model_height
+        self.filament_grams: float = filament_grams
+        self.filament_cost: float = filament_cost
+        self.currency: str = currency if currency else "€"
+
+
+class ThumbnailGenerator:
+    _corner_choices: dict[str, Callable[[SliceData], str]]
+
+    @staticmethod
+    def _nothing(slice_data: SliceData) -> str:
+        return ""
+
+    @staticmethod
+    def _time_estimate(slice_data: SliceData) -> str:
+        time_minutes: int = math.floor(slice_data.time_seconds / 60)
+        return f"⧖ {time_minutes // 60}:{time_minutes % 60:02d}h"
+
+    @staticmethod
+    def _filament_grams_estimate(slice_data: SliceData) -> str:
+        return f"⭗ {round(slice_data.filament_grams)}g"
+
+    @staticmethod
+    def _model_height(slice_data: SliceData) -> str:
+        if slice_data.model_height < 0:
+            return f"⭱ N/A"
+        else:
+            return f"⭱ {round(slice_data.model_height, 2)}mm"
+
+    @staticmethod
+    def _filament_cost_estimate(slice_data: SliceData) -> str:
+        return f"⛁ {round(slice_data.filament_cost, 2):.02f}{slice_data.currency}"
+
+    @classmethod
+    def available_options(cls) -> List[str]:
+        return list(cls._corner_choices)
+
+    @classmethod
+    def calculate_option(cls, option: str, slice_data: SliceData) -> str:
+        func = cls._corner_choices.get(option, None)
+        if func is not None:
+            return func(slice_data)
+        else:
+            return ""
+
+    @classmethod
+    def generate_option_lines(cls, corner_options, slice_data: SliceData) -> list[str]:
+        """
+        Generate the texts for the corners from settings
+        """
+        lines: list[str] = []
+        for option in corner_options:
+            line = cls.calculate_option(option, slice_data)
+            lines.append(line)
+        return lines
+
+ThumbnailGenerator._corner_choices = {
+    "nothing": ThumbnailGenerator._nothing,
+    "time_estimate": ThumbnailGenerator._time_estimate,
+    "filament_grams_estimate": ThumbnailGenerator._filament_grams_estimate,
+    "model_height": ThumbnailGenerator._model_height,
+    "filament_cost_estimate": ThumbnailGenerator._filament_cost_estimate,
+}


### PR DESCRIPTION
I originally used the Cura plugin with it and I preferred a different corner layout. I've looked at the Cura code and adapted it to this plugin so that all values from Cura are available as well as custom placement.

I tried to implement the logic, which writes the metadata information, without any slicer in mind. So in theory it is possible to "backport" some part of the implementation so that it is easier to keep both in sync. For example the `SliceData` class is basically identical (except the printer model).